### PR TITLE
[MOB-53] Fixed not being able to switch between WHIP/WHEP tabs - React Native

### DIFF
--- a/examples/react-native/WhipWhepDemo/app/(tabs)/_layout.tsx
+++ b/examples/react-native/WhipWhepDemo/app/(tabs)/_layout.tsx
@@ -24,6 +24,7 @@ export default function TabLayout() {
               color={color}
             />
           ),
+          unmountOnBlur: true,
         }}
       />
       <Tabs.Screen
@@ -36,6 +37,7 @@ export default function TabLayout() {
               color={color}
             />
           ),
+          unmountOnBlur: true,
         }}
       />
     </Tabs>


### PR DESCRIPTION
Added unmounting the tab so that the clients disconnect and the app doesn't crash when switching between tabs.