### PR TITLE
[MOB-65] Add small fixes to the documentation and code

### DIFF
--- a/examples/ios/WhipWhepDemo/WhipWhepDemo/ContentView.swift
+++ b/examples/ios/WhipWhepDemo/WhipWhepDemo/ContentView.swift
@@ -16,8 +16,8 @@ struct ContentView: View {
             }
         }
     @State var whepBroadcaster = WhepClient(serverUrl: URL(string: "https://broadcaster.elixir-webrtc.org/api/whep")!, configurationOptions: ConfigurationOptions(authToken: "example"))
-    @State var whepPlayer = WhepClient(serverUrl: URL(string: "\(Bundle.main.infoDictionary?["WhepServerUrl"] as? String ?? "")")!, configurationOptions: ConfigurationOptions(authToken: "example"))
-    @State var whipPlayer = WhipClient(serverUrl: URL(string: "\(Bundle.main.infoDictionary?["WhipServerUrl"] as? String ?? "")")!, configurationOptions: ConfigurationOptions(authToken: "example"), videoDevice: WhipClient.getCaptureDevices().first)
+    @State var whepPlayer = WhepClient(serverUrl: URL(string: Bundle.main.infoDictionary?["WhepServerUrl"] as? String ?? "")!, configurationOptions: ConfigurationOptions(authToken: "example"))
+    @State var whipPlayer = WhipClient(serverUrl: URL(string: Bundle.main.infoDictionary?["WhipServerUrl"] as? String ?? "")!, configurationOptions: ConfigurationOptions(authToken: "example"), videoDevice: WhipClient.getCaptureDevices().first)
     
     var body: some View {
         VStack {

--- a/packages/react-native-client/README.md
+++ b/packages/react-native-client/README.md
@@ -64,6 +64,8 @@ If the project is a bare React Native project, it is required to install `expo-m
 $ npx install-expo-modules
 ```
 
+For more information and troubleshooting, visit [expo-modules documentation](https://docs.expo.dev/bare/installing-expo-modules/).
+
 It is necessary to configure app permissions in order to stream a preview from the camera or sound:
 
 #### Android

--- a/packages/react-native-client/README.md
+++ b/packages/react-native-client/README.md
@@ -6,21 +6,19 @@ This repository is an expo module that makes use of native Android and iOS packa
 
 ## Setup
 
+Install the package using `npm` or `yarn`:
+
 ```
 $ npm install --save react-native-whip-whep
 # --- or ---
 $ yarn add react-native-whip-whep
 ```
 
-Install `expo-modules`:
-
-```
-$ npx install-expo-modules
-```
+### With Expo
 
 It is necessary to configure app permissions in order to stream a preview from the camera or sound:
 
-### Android
+#### Android
 
 Modify `app.json` file to request necessary permissions:
 
@@ -30,16 +28,16 @@ Modify `app.json` file to request necessary permissions:
     ...
     "android": {
       ...
-      "permissions": {
+      "permissions": [
         "android.permission.CAMERA",
         "android.permission.RECORD_AUDIO"
-      }
+      ]
     }
   }
 }
 ```
 
-### iOS
+#### iOS
 
 Add the following lines to `app.json`:
 
@@ -56,6 +54,40 @@ Add the following lines to `app.json`:
     },
   }
 }
+```
+
+### Without Expo
+
+If the project is a bare React Native project, it is required to install `expo-modules`:
+
+```
+$ npx install-expo-modules
+```
+
+It is necessary to configure app permissions in order to stream a preview from the camera or sound:
+
+#### Android
+
+Modify `AndroidManifest.xml` file to request necessary permissions:
+
+```xml
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+  ...
+  <uses-permission android:name="android.permission.CAMERA"/>
+  <uses-permission android:name="android.permission.RECORD_AUDIO"/>
+  ...
+</manifest>
+```
+
+#### iOS
+
+Add the following lines to `info.plist`:
+
+```plist
+<key>NSCameraUsageDescription</key>
+<string>This application requires camera access to gather information about available video devices.</string>
+<key>NSMicrophoneUsageDescription</key>
+<string>This application requires microphone access to gather information about available audio devices.</string>
 ```
 
 ## Usage

--- a/packages/react-native-client/README.md
+++ b/packages/react-native-client/README.md
@@ -12,6 +12,12 @@ $ npm install --save react-native-whip-whep
 $ yarn add react-native-whip-whep
 ```
 
+Install `expo-modules`:
+
+```
+$ npx install-expo-modules
+```
+
 It is necessary to configure app permissions in order to stream a preview from the camera or sound:
 
 ### Android


### PR DESCRIPTION
- Removed string interpolation from iOS example
- Added info about installing `expo-modules`