### PR TITLE
[MOB-43] Fixed Android audio using call speaker instead of media one

### DIFF
--- a/packages/android-client/MobileWhepClient/src/main/java/com/mobilewhep/client/AudioDeviceModule.kt
+++ b/packages/android-client/MobileWhepClient/src/main/java/com/mobilewhep/client/AudioDeviceModule.kt
@@ -6,7 +6,10 @@ import android.util.Log
 import org.webrtc.audio.AudioDeviceModule
 import org.webrtc.audio.JavaAudioDeviceModule
 
-fun createAudioDeviceModule(appContext: Context, audioAttributes: AudioAttributes): AudioDeviceModule {
+fun createAudioDeviceModule(
+  appContext: Context,
+  audioAttributes: AudioAttributes
+): AudioDeviceModule {
   val audioRecordErrorCallback =
     object : JavaAudioDeviceModule.AudioRecordErrorCallback {
       override fun onWebRtcAudioRecordInitError(errorMessage: String?) {

--- a/packages/android-client/MobileWhepClient/src/main/java/com/mobilewhep/client/AudioDeviceModule.kt
+++ b/packages/android-client/MobileWhepClient/src/main/java/com/mobilewhep/client/AudioDeviceModule.kt
@@ -1,0 +1,78 @@
+package com.mobilewhep.client
+
+import android.content.Context
+import android.media.AudioAttributes
+import android.util.Log
+import org.webrtc.audio.AudioDeviceModule
+import org.webrtc.audio.JavaAudioDeviceModule
+
+fun createAudioDeviceModule(appContext: Context, audioAttributes: AudioAttributes): AudioDeviceModule {
+  val audioRecordErrorCallback =
+    object : JavaAudioDeviceModule.AudioRecordErrorCallback {
+      override fun onWebRtcAudioRecordInitError(errorMessage: String?) {
+        Log.e("AudioDeviceModule", "onWebRtcAudioRecordInitError: $errorMessage")
+      }
+
+      override fun onWebRtcAudioRecordStartError(
+        errorCode: JavaAudioDeviceModule.AudioRecordStartErrorCode?,
+        errorMessage: String?
+      ) {
+        Log.e("AudioDeviceModule", "onWebRtcAudioRecordStartError: $errorCode. $errorMessage")
+      }
+
+      override fun onWebRtcAudioRecordError(errorMessage: String?) {
+        Log.e("AudioDeviceModule", "onWebRtcAudioRecordError: $errorMessage")
+      }
+    }
+
+  val audioTrackErrorCallback =
+    object : JavaAudioDeviceModule.AudioTrackErrorCallback {
+      override fun onWebRtcAudioTrackInitError(errorMessage: String?) {
+        Log.e("AudioDeviceModule", "onWebRtcAudioTrackInitError: $errorMessage")
+      }
+
+      override fun onWebRtcAudioTrackStartError(
+        errorCode: JavaAudioDeviceModule.AudioTrackStartErrorCode?,
+        errorMessage: String?
+      ) {
+        Log.e("AudioDeviceModule", "onWebRtcAudioTrackStartError: $errorCode. $errorMessage")
+      }
+
+      override fun onWebRtcAudioTrackError(errorMessage: String?) {
+        Log.e("AudioDeviceModule", "onWebRtcAudioTrackError: $errorMessage")
+      }
+    }
+
+  val audioRecordStateCallback: JavaAudioDeviceModule.AudioRecordStateCallback =
+    object : JavaAudioDeviceModule.AudioRecordStateCallback {
+      override fun onWebRtcAudioRecordStart() {
+        Log.i("AudioDeviceModule", "Audio recording starts")
+      }
+
+      override fun onWebRtcAudioRecordStop() {
+        Log.i("AudioDeviceModule", "Audio recording stops")
+      }
+    }
+
+  val audioTrackStateCallback: JavaAudioDeviceModule.AudioTrackStateCallback =
+    object : JavaAudioDeviceModule.AudioTrackStateCallback {
+      override fun onWebRtcAudioTrackStart() {
+        Log.i("AudioDeviceModule", "Audio playout starts")
+      }
+
+      override fun onWebRtcAudioTrackStop() {
+        Log.i("AudioDeviceModule", "Audio playout stops")
+      }
+    }
+
+  return JavaAudioDeviceModule
+    .builder(appContext)
+    .setUseHardwareAcousticEchoCanceler(true)
+    .setUseHardwareNoiseSuppressor(true)
+    .setAudioRecordErrorCallback(audioRecordErrorCallback)
+    .setAudioTrackErrorCallback(audioTrackErrorCallback)
+    .setAudioRecordStateCallback(audioRecordStateCallback)
+    .setAudioTrackStateCallback(audioTrackStateCallback)
+    .setAudioAttributes(audioAttributes)
+    .createAudioDeviceModule()
+}

--- a/packages/android-client/MobileWhepClient/src/main/java/com/mobilewhep/client/ClientBase.kt
+++ b/packages/android-client/MobileWhepClient/src/main/java/com/mobilewhep/client/ClientBase.kt
@@ -3,6 +3,7 @@ package com.mobilewhep.client
 import android.Manifest
 import android.content.Context
 import android.content.pm.PackageManager
+import android.media.AudioAttributes
 import android.util.Log
 import androidx.core.content.ContextCompat
 import kotlinx.coroutines.CoroutineScope
@@ -25,6 +26,7 @@ import org.webrtc.PeerConnection
 import org.webrtc.PeerConnectionFactory
 import org.webrtc.RtpReceiver
 import org.webrtc.VideoTrack
+import org.webrtc.audio.AudioDeviceModule
 import java.io.IOException
 import java.net.ConnectException
 import java.net.URI
@@ -52,6 +54,13 @@ open class ClientBase(
   protected val iceCandidates = mutableListOf<IceCandidate>()
 
   private val client = OkHttpClient()
+  private val audioAttributes: AudioAttributes =
+    AudioAttributes
+      .Builder()
+      .setUsage(AudioAttributes.USAGE_MEDIA)
+      .setContentType(AudioAttributes.CONTENT_TYPE_MOVIE)
+      .build()
+  private val audioDeviceModule: AudioDeviceModule = createAudioDeviceModule(appContext, audioAttributes)
 
   private val coroutineScope: CoroutineScope =
     CoroutineScope(Dispatchers.Default)
@@ -90,6 +99,7 @@ open class ClientBase(
     peerConnectionFactory =
       PeerConnectionFactory
         .builder()
+        .setAudioDeviceModule(audioDeviceModule)
         .setVideoDecoderFactory(DefaultVideoDecoderFactory(eglBase.eglBaseContext))
         .setVideoEncoderFactory(DefaultVideoEncoderFactory(eglBase.eglBaseContext, true, true))
         .createPeerConnectionFactory()


### PR DESCRIPTION
Added AudioDeviceModule to specify the output type, so that the audio is played through media speaker. Tested this on a regular media speaker, bluetooth earphones and cable earphones.