### PR TITLE
Add dynamic banner serving to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 <img src="./.github/images/whipwhep_github.png" width="100%">
 
+[![Ad](https://swm-delivery.com/www/images/zone-gh-react-native-whip-whep-1?n=1)](https://swm-delivery.com/www/delivery/ck.php?zoneid=zone-gh-react-native-whip-whep-1&n=1)
+[![Ad](https://swm-delivery.com/www/images/zone-gh-react-native-whip-whep-2?n=1)](https://swm-delivery.com/www/delivery/ck.php?zoneid=zone-gh-react-native-whip-whep-2&n=1)
+[![Ad](https://swm-delivery.com/www/images/zone-gh-react-native-whip-whep-3?n=1)](https://swm-delivery.com/www/delivery/ck.php?zoneid=zone-gh-react-native-whip-whep-3&n=1)
+
 # WHIP/WHEP Mobile Client
 
 Monorepo containing mobile SDKs for WHIP/WHEP client

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 <img src="./.github/images/whipwhep_github.png" width="100%">
 
-[![Ad](https://swm-delivery.com/www/images/zone-gh-react-native-whip-whep-1?n=1)](https://swm-delivery.com/www/delivery/ck.php?zoneid=zone-gh-react-native-whip-whep-1&n=1)
-[![Ad](https://swm-delivery.com/www/images/zone-gh-react-native-whip-whep-2?n=1)](https://swm-delivery.com/www/delivery/ck.php?zoneid=zone-gh-react-native-whip-whep-2&n=1)
-[![Ad](https://swm-delivery.com/www/images/zone-gh-react-native-whip-whep-3?n=1)](https://swm-delivery.com/www/delivery/ck.php?zoneid=zone-gh-react-native-whip-whep-3&n=1)
+[![Ad](https://swm-delivery.com/www/images/zone-gh-react-native-whip-whep-1?n=1)](https://swm-delivery.com/www/delivery/ck-slug.php?zoneid=zone-gh-react-native-whip-whep-1&n=1)
+[![Ad](https://swm-delivery.com/www/images/zone-gh-react-native-whip-whep-2?n=1)](https://swm-delivery.com/www/delivery/ck-slug.php?zoneid=zone-gh-react-native-whip-whep-2&n=1)
+[![Ad](https://swm-delivery.com/www/images/zone-gh-react-native-whip-whep-3?n=1)](https://swm-delivery.com/www/delivery/ck-slug.php?zoneid=zone-gh-react-native-whip-whep-3&n=1)
 
 # WHIP/WHEP Mobile Client
 


### PR DESCRIPTION
Adds dynamic banners to readme. The image and link are served from our delivery server, so we can swap banners without changing the repo. Banners are hidden for now until we turn them on.